### PR TITLE
docs(modules): add community module kubectl

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -56,6 +56,7 @@ Community Modules
 
 These are modules provided by users of the community
 
-| Name                                                            | Description                                                             |
-| --------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| [kiesman99/zim-zoxide](https://github.com/kiesman99/zim-zoxide) | Sets up [zoxide](https://github.com/ajeetdsouza/zoxide) in zsh.         |
+| Name                                                            | Description                                                                              |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [joke/zim-kubectl](https://github.com/joke/zim-kubectl)         | Sets up [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/) in zsh.         |
+| [kiesman99/zim-zoxide](https://github.com/kiesman99/zim-zoxide) | Sets up [zoxide](https://github.com/ajeetdsouza/zoxide) in zsh.                          |


### PR DESCRIPTION
I sorted the rows in alphabetical order based on the module name (kubectl before zoxide)