### PR TITLE
Fix typo in homepage

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -172,7 +172,7 @@ title: Home
   <script src="https://cdnjs.cloudflare.com/ajax/libs/TypewriterJS/2.13.1/core.min.js"></script>
   <script>
     new Typewriter('#typewriter', {
-      strings: ['super fast', 'working for you', 'powerfully intergrated', 'just how you like it'],
+      strings: ['super fast', 'working for you', 'powerfully integrated', 'just how you like it'],
       autoStart: true,
       loop: true,
     });


### PR DESCRIPTION
The "your terminal: ..." section seems to have a typo (intergrated instead of integrated).

If this is incorrect (maybe I'm missing some context), simply reject this PR.

I'm still learning the social conventions of OSS collaboration. If opening this PR was not the ideal approach (perhaps an issue is more appropriate?), please inform me.

Trying out Zim now, hope zsh-bench gives me some good numbers :crossed_fingers: